### PR TITLE
Update hashlist per Habib's patched ROS 4.60CEX

### DIFF
--- a/Latest Compiled Version/default.hashlist
+++ b/Latest Compiled Version/default.hashlist
@@ -10,7 +10,7 @@
   </offsets>
   <type name="ROS">
     <hash name="4.60 CEX Patched (Habib)" size="6FFFE0">
-      CBAFDBA013864934A9229BCE64CE91ED
+      E43861300294CAD85FF3985536206085
     </hash>
     <hash name="4.60 CEX" size="6FFFE0">
       CBAFDBA013864934A9229BCE64CE91ED


### PR DESCRIPTION
Source of patchs : http://psx-scene.com/forums/content/habib-4-60-v1-00-4533/
http://www.mediafire.com/download/54d841120mfbbuo/habib_patcher_v1.00.rar
